### PR TITLE
Fix history button selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@ dialog{ border:1px solid var(--glass-border); background:var(--glass); color:var
               <button class="btn" id="newMeasurementBtn" data-lang="btn_new_busbar">New Busbar (Clear)</button>
             </div>
             <div class="toolbar">
-              <button class="btn" id="showHistoryBtn" data-lang="btn_history">View History (CSV/Edit)</button>
+              <button class="btn" id="viewHistoryBtn" data-lang="btn_history">View History (CSV/Edit)</button>
               <button class="btn" id="showChartsBtn" data-lang="btn_charts">Visualization (Charts)</button>
             </div>
             <div class="toolbar">


### PR DESCRIPTION
## Summary
- rename the history action button id to match the initialization listener so it opens the history modal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd70e80dc8833281a110884e32a8e6